### PR TITLE
Don't alert on Consul services down if consul itself is not healthy

### DIFF
--- a/nubis/puppet/files/rules/nubis.prom
+++ b/nubis/puppet/files/rules/nubis.prom
@@ -19,7 +19,7 @@ ALERT ConsulDown
 # We expect all our Consul services to have at least 1 healthy member
 # Except for tainted instances, these we filter out here
 ALERT ConsulServiceDown
-  IF drop_common_labels(label_replace(label_replace(min(consul_catalog_service_node_healthy{service!="tainted"}) BY (service,node), "instance", "$1", "node", "(.*)"), "node", "XXX", "node", ".*")) * ON(instance) GROUP_LEFT(project, environment, account) nubis * ON(instance) GROUP_LEFT(instance_type, availability_zone, region) aws < 1
+  IF drop_common_labels(label_replace(label_replace(min(consul_catalog_service_node_healthy{service!="tainted"}) BY (service, node)  - ON  (node) GROUP_LEFT(instance) min(consul_agent_check{check="serfHealth"}) BY (node), "instance", "$1", "node", "(.*)"), "node", "XXX", "node", ".*")) * ON(instance) GROUP_LEFT(project, environment, account) nubis * ON(instance) GROUP_LEFT(instance_type, availability_zone, region) aws < 0
   FOR 5m
   LABELS { severity = "critical" }
   ANNOTATIONS {


### PR DESCRIPTION
Otherwise, we get false alerts for dead nodes until consul reaps them