### PR TITLE
Little improvements for Prometheus Backups

### DIFF
--- a/nubis/puppet/backups.pp
+++ b/nubis/puppet/backups.pp
@@ -23,11 +23,16 @@ file { '/var/lib/prometheus/PRISTINE':
 }
 
 cron::hourly { 'prometheus-backup':
+    minute  => fqdn_rand(60),
     user    => 'root',
     command => 'nubis-cron prometheus-backup /usr/local/bin/nubis-prometheus-backup save',
 }
 
+# We want this cronjob to be 30 minutes offset from the backup one, just to avoid overlap
 cron::daily { 'prometheus-backup-cleanup':
+    minute  => ( fqdn_rand(60) + 30 ) % 60,
+    # Run between midnight and 4 am
+    hour    => fqdn_rand(4),
     user    => 'root',
     command => 'nubis-cron prometheus-backup-cleanup /usr/local/bin/nubis-prometheus-backup purge',
 }

--- a/nubis/puppet/files/backup
+++ b/nubis/puppet/files/backup
@@ -22,7 +22,7 @@ save() {
   fi
 
   # Backup
-  duply prometheus backup --force --allow-source-mismatch
+  run_duply prometheus backup --force --allow-source-mismatch
 }
 
 restore() {
@@ -34,7 +34,7 @@ restore() {
   rm -rf /var/lib/prometheus/*
 
   # Recover
-  duply prometheus restore /var/lib/prometheus --force
+  run_duply prometheus restore /var/lib/prometheus --force
 
   # Cleanup just to be certain
   rm -f /var/lib/prometheus/PRISTINE
@@ -44,7 +44,16 @@ restore() {
 
 purge() {
   # Cleanup and expire backups
-  duply prometheus purge_cleanup  --force
+  run_duply prometheus purge_cleanup  --force
+}
+
+# We run duply under an exclusive lock, to avoid parallel execution
+# shellcheck disable=SC2094
+run_duply() {
+  (
+    flock -x 9
+    /usr/local/bin/duply "$@"
+  ) 9< /usr/local/bin/duply
 }
 
 case "$1" in


### PR DESCRIPTION
Forgotten behind: 
 - randomize cron execution time
 - prevent duply/duplicity concurrent executions