### PR TITLE
Fix blackbox exporter to start up

### DIFF
--- a/nubis/puppet/prometheus.pp
+++ b/nubis/puppet/prometheus.pp
@@ -208,7 +208,7 @@ upstart::job { 'blackbox':
     . /etc/profile.d/proxy.sh
   fi
 
-  exec /opt/prometheus/blackbox_exporter -config.file /etc/prometheus/blackbox.yml -log.level info -log.format "logger:syslog?appname=blackbox_exporter&local=7"
+  exec /opt/prometheus/blackbox_exporter --config.file /etc/prometheus/blackbox.yml --log.level info
 ',
     post_stop      => '
 goal=$(initctl status $UPSTART_JOB | awk \'{print $2}\' | cut -d \'/\' -f 1)


### PR DESCRIPTION
The flags have changed so we now need to change the upstart job. Fixes #271 