### PR TITLE
Upgrade Prometheus, AlertManager, Traefik & blackbox_exporter

### DIFF
--- a/nubis/puppet/prometheus.pp
+++ b/nubis/puppet/prometheus.pp
@@ -1,6 +1,6 @@
-$prometheus_version = '2.1.0'
-$alertmanager_version = '0.13.0'
-$blackbox_version = '0.11.0'
+$prometheus_version = '2.2.1'
+$alertmanager_version = '0.14.0'
+$blackbox_version = '0.12.0'
 
 $prometheus_url = "https://github.com/prometheus/prometheus/releases/download/v${prometheus_version}/prometheus-${prometheus_version}.linux-amd64.tar.gz"
 $alertmanager_url = "https://github.com/prometheus/alertmanager/releases/download/v${alertmanager_version}/alertmanager-${alertmanager_version}.linux-amd64.tar.gz"

--- a/nubis/puppet/traefik.pp
+++ b/nubis/puppet/traefik.pp
@@ -1,4 +1,4 @@
-$traefik_version = '1.5.0'
+$traefik_version = '1.5.4'
 $traefik_url = "https://github.com/containous/traefik/releases/download/v${traefik_version}/traefik_linux-amd64"
 
 notice ("Grabbing traefik ${traefik_version}")


### PR DESCRIPTION
Upgrade Traefik to 1.5.4 : Fixes #342
Upgrade blackbox_exporter to 0.12.0: Fixes #341
Upgrade AlertManager to 0.14.0: Fixes #340
Upgrade to Prometheus 2.2.1: Fixes #339